### PR TITLE
Add norm implementation without BLAS/LAPACK dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "SimpleNorm"
+uuid = "ed573fae-7fee-4d61-b037-fdc8e83b28d4"
+authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
+version = "0.1.0"
+
+[compat]
+julia = "1.6"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # SimpleNorm.jl
-Implementation of a norm function without LinearAlgebra.jl / BLAS / LAPACK
+
+A lightweight implementation of norm functions without LinearAlgebra.jl, BLAS, or LAPACK dependencies.
+
+## Features
+
+This package provides pure Julia implementations of common norm functions:
+
+### Vector norms
+- `norm(x)` or `norm(x, 2)` - Euclidean norm (default)
+- `norm(x, 1)` - 1-norm (sum of absolute values)
+- `norm(x, Inf)` - Infinity norm (maximum absolute value)
+- `norm(x, -Inf)` - Minimum absolute value
+- `norm(x, p)` - p-norm for any `p ≥ 1`
+- `norm(x, 0)` - Count of non-zero elements
+
+### Matrix norms
+- `norm(A, 1)` - Maximum absolute column sum
+- `norm(A, Inf)` - Maximum absolute row sum
+- `norm(A, "fro")` or `norm(A, :fro)` - Frobenius norm
+
+Note: The spectral norm (`norm(A, 2)`) is not implemented as it requires singular value decomposition.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("SimpleNorm")
+```
+
+## Usage
+
+```julia
+using SimpleNorm
+
+# Vector norms
+v = [3.0, 4.0]
+norm(v)       # 5.0 (Euclidean norm)
+norm(v, 1)    # 7.0 (1-norm)
+norm(v, Inf)  # 4.0 (infinity norm)
+
+# Matrix norms
+A = [1 2 3; 4 5 6]
+norm(A, 1)    # 9.0 (max column sum)
+norm(A, Inf)  # 15.0 (max row sum)
+norm(A, "fro") # Frobenius norm
+```
+
+## Why SimpleNorm.jl?
+
+This package is useful when you need norm computations but want to avoid:
+- Binary dependencies (BLAS/LAPACK)
+- Heavy LinearAlgebra.jl dependency
+- Deployment issues in constrained environments
+
+All implementations are in pure Julia with careful attention to numerical stability, including overflow/underflow prevention in the 2-norm calculation.

--- a/src/SimpleNorm.jl
+++ b/src/SimpleNorm.jl
@@ -1,0 +1,227 @@
+module SimpleNorm
+
+export norm
+
+"""
+    norm(x, p::Real=2)
+
+Compute the p-norm of a vector or array.
+
+For vectors and arrays, the p-norm is defined as:
+- `p = 1`: sum of absolute values
+- `p = 2`: Euclidean norm (default)
+- `p = Inf`: maximum absolute value
+- `p = -Inf`: minimum absolute value
+- `p > 0`: (Σ|xᵢ|^p)^(1/p)
+
+For matrices, special norms are supported:
+- `p = 1`: maximum column sum
+- `p = Inf`: maximum row sum
+- `p = "fro"` or `p = :fro`: Frobenius norm
+- `p = 2`: spectral norm (not implemented - would require SVD)
+
+This implementation does not depend on BLAS or LAPACK.
+"""
+norm(x) = norm(x, 2)
+
+# Dispatch for vectors and general arrays with numeric p
+function norm(x::AbstractArray{T}, p::Real) where {T}
+    # For matrices, handle matrix-specific norms
+    if ndims(x) == 2
+        return _matrix_norm(x, p)
+    end
+
+    # Vector and general array norms
+    if isempty(x)
+        return float(abs(zero(T)))
+    end
+
+    if p == 2
+        return norm2(x)
+    elseif p == 1
+        return norm1(x)
+    elseif p == Inf
+        return normInf(x)
+    elseif p == -Inf
+        return normMinusInf(x)
+    elseif p == 0
+        return norm0(x)
+    elseif p > 0
+        return normp(x, p)
+    else
+        throw(ArgumentError("p-norm is not defined for p < 0 (except p = -Inf)"))
+    end
+end
+
+# Dispatch for matrix string/symbol norms
+function norm(A::AbstractMatrix, p::Union{AbstractString, Symbol})
+    if p in ("fro", :fro)
+        return normFrobenius(A)
+    else
+        throw(ArgumentError("Unknown matrix norm: $p"))
+    end
+end
+
+# Internal function for matrix norms with numeric p
+function _matrix_norm(A::AbstractMatrix, p::Real)
+    if p == 1
+        return norm1_matrix(A)
+    elseif p == Inf
+        return normInf_matrix(A)
+    elseif p == 2
+        error("Spectral norm (2-norm) for matrices requires singular value decomposition, which is not implemented in SimpleNorm.jl to avoid dependencies.")
+    else
+        throw(ArgumentError("Matrix norm not supported for p = $p"))
+    end
+end
+
+# Specialized implementations for common norms
+
+function norm1(x)
+    s = float(abs(zero(eltype(x))))
+    for xi in x
+        s += abs(xi)
+    end
+    return s
+end
+
+function norm2(x)
+    # Use a scaling algorithm to avoid overflow/underflow
+    # Similar to BLAS dnrm2 but in pure Julia
+    T = float(real(eltype(x)))
+
+    # Find the maximum absolute value for scaling
+    scale = zero(T)
+    for xi in x
+        scale = max(scale, abs(xi))
+    end
+
+    if scale == zero(T)
+        return zero(T)
+    elseif isinf(scale)
+        return T(Inf)
+    end
+
+    # Compute scaled sum of squares
+    sumsq = zero(T)
+    for xi in x
+        sumsq += abs2(xi / scale)
+    end
+
+    return scale * sqrt(sumsq)
+end
+
+function normInf(x)
+    if isempty(x)
+        return float(abs(zero(eltype(x))))
+    end
+
+    m = abs(first(x))
+    for xi in x
+        m = max(m, abs(xi))
+    end
+    return float(m)
+end
+
+function normMinusInf(x)
+    if isempty(x)
+        return float(abs(zero(eltype(x))))
+    end
+
+    m = abs(first(x))
+    for xi in x
+        m = min(m, abs(xi))
+    end
+    return float(m)
+end
+
+function norm0(x)
+    # Count non-zero elements
+    count = 0
+    for xi in x
+        if xi != zero(xi)
+            count += 1
+        end
+    end
+    return float(count)
+end
+
+function normp(x, p::Real)
+    T = float(real(eltype(x)))
+
+    if p == 1
+        return norm1(x)
+    elseif p == 2
+        return norm2(x)
+    elseif isinf(p)
+        return normInf(x)
+    end
+
+    # General p-norm with scaling to avoid overflow
+    scale = zero(T)
+    for xi in x
+        scale = max(scale, abs(xi))
+    end
+
+    if scale == zero(T)
+        return zero(T)
+    elseif isinf(scale)
+        return T(Inf)
+    end
+
+    # Compute scaled p-norm
+    sump = zero(T)
+    for xi in x
+        sump += abs(xi / scale)^p
+    end
+
+    return scale * sump^(1/p)
+end
+
+# Matrix norm implementations
+
+function norm1_matrix(A::AbstractMatrix)
+    m, n = size(A)
+    if m == 0 || n == 0
+        return float(abs(zero(eltype(A))))
+    end
+
+    # Maximum absolute column sum
+    maxsum = zero(float(real(eltype(A))))
+    for j in 1:n
+        colsum = zero(float(real(eltype(A))))
+        for i in 1:m
+            colsum += abs(A[i, j])
+        end
+        maxsum = max(maxsum, colsum)
+    end
+    return maxsum
+end
+
+function normInf_matrix(A::AbstractMatrix)
+    m, n = size(A)
+    if m == 0 || n == 0
+        return float(abs(zero(eltype(A))))
+    end
+
+    # Maximum absolute row sum
+    maxsum = zero(float(real(eltype(A))))
+    for i in 1:m
+        rowsum = zero(float(real(eltype(A))))
+        for j in 1:n
+            rowsum += abs(A[i, j])
+        end
+        maxsum = max(maxsum, rowsum)
+    end
+    return maxsum
+end
+
+function normFrobenius(A::AbstractMatrix)
+    # Frobenius norm is just the 2-norm of A viewed as a vector
+    return norm2(A)
+end
+
+# Type conversion for norm of numbers
+norm(x::Number, p::Real = 2) = abs(x)
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,141 @@
+using SimpleNorm
+using Test
+
+@testset "SimpleNorm.jl" begin
+    @testset "Vector norms" begin
+        # Test vectors
+        v1 = [3.0, 4.0]
+        v2 = [1.0, -2.0, 3.0, -4.0]
+        v3 = Float64[]
+        v4 = [1.0 + 2.0im, 3.0 - 4.0im]
+
+        # 2-norm (default)
+        @test norm(v1) ≈ 5.0
+        @test norm(v1, 2) ≈ 5.0
+        @test norm(v2, 2) ≈ sqrt(1 + 4 + 9 + 16)
+        @test norm(v3) == 0.0
+
+        # 1-norm
+        @test norm(v1, 1) ≈ 7.0
+        @test norm(v2, 1) ≈ 10.0
+        @test norm(v3, 1) == 0.0
+
+        # Infinity norm
+        @test norm(v1, Inf) ≈ 4.0
+        @test norm(v2, Inf) ≈ 4.0
+        @test norm(v3, Inf) == 0.0
+
+        # Negative infinity norm
+        @test norm(v1, -Inf) ≈ 3.0
+        @test norm(v2, -Inf) ≈ 1.0
+
+        # 0-norm (counting non-zeros)
+        @test norm(v1, 0) == 2.0
+        @test norm(v2, 0) == 4.0
+        @test norm([1.0, 0.0, 3.0, 0.0, 5.0], 0) == 3.0
+
+        # p-norm for various p
+        @test norm(v1, 3) ≈ (3^3 + 4^3)^(1/3)
+        @test norm(v2, 4) ≈ (1 + 16 + 81 + 256)^(1/4)
+
+        # Complex vectors
+        @test norm(v4, 1) ≈ sqrt(5) + 5
+        @test norm(v4, 2) ≈ sqrt(5 + 25)
+        @test norm(v4, Inf) ≈ 5.0
+    end
+
+    @testset "Matrix norms" begin
+        A = [1.0 2.0 3.0;
+             4.0 5.0 6.0]
+
+        B = [1.0 -2.0;
+             3.0 4.0;
+             -5.0 6.0]
+
+        # 1-norm (maximum column sum)
+        @test norm(A, 1) ≈ 9.0  # max(1+4, 2+5, 3+6)
+        @test norm(B, 1) ≈ 12.0  # max(1+3+5, 2+4+6)
+
+        # Infinity norm (maximum row sum)
+        @test norm(A, Inf) ≈ 15.0  # max(1+2+3, 4+5+6)
+        @test norm(B, Inf) ≈ 11.0  # max(1+2, 3+4, 5+6)
+
+        # Frobenius norm
+        @test norm(A, "fro") ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
+        @test norm(A, :fro) ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
+        @test norm(B, "fro") ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
+
+        # Empty matrix
+        @test norm(zeros(0, 0), 1) == 0.0
+        @test norm(zeros(0, 5), 1) == 0.0
+        @test norm(zeros(5, 0), Inf) == 0.0
+    end
+
+    @testset "Scalar norms" begin
+        @test norm(5.0) == 5.0
+        @test norm(-3.0) == 3.0
+        @test norm(3.0 + 4.0im) == 5.0
+        @test norm(0.0) == 0.0
+
+        # All p-norms of a scalar should return absolute value
+        @test norm(5.0, 1) == 5.0
+        @test norm(-3.0, 2) == 3.0
+        @test norm(5.0, Inf) == 5.0
+    end
+
+    @testset "Special cases" begin
+        # Infinity and NaN handling
+        v_inf = [1.0, Inf, 3.0]
+        v_nan = [1.0, NaN, 3.0]
+
+        @test norm(v_inf, 1) == Inf
+        @test norm(v_inf, 2) == Inf
+        @test norm(v_inf, Inf) == Inf
+        @test isnan(norm(v_nan, 1))
+        @test isnan(norm(v_nan, 2))
+        @test isnan(norm(v_nan, Inf))
+
+        # Large values (overflow prevention)
+        large_val = 1e308
+        v_large = [large_val, large_val]
+        @test norm(v_large, 2) ≈ sqrt(2) * large_val
+        @test !isinf(norm(v_large, 2))
+
+        # Small values (underflow prevention)
+        small_val = 1e-308
+        v_small = [small_val, small_val]
+        @test norm(v_small, 2) ≈ sqrt(2) * small_val
+        @test norm(v_small, 2) > 0
+    end
+
+    @testset "Error handling" begin
+        v = [1.0, 2.0, 3.0]
+
+        # Invalid p values
+        @test_throws ArgumentError norm(v, -2)
+        @test_throws ArgumentError norm(v, -0.5)
+
+        # Matrix 2-norm not implemented
+        A = [1.0 2.0; 3.0 4.0]
+        @test_throws ErrorException norm(A, 2)
+
+        # Invalid matrix norm
+        @test_throws ArgumentError norm(A, 3)
+    end
+
+    @testset "Type stability" begin
+        # Test that output types are predictable
+        v_int = [1, 2, 3]
+        v_float = [1.0, 2.0, 3.0]
+        v_complex = [1.0 + 0.0im, 2.0 + 0.0im]
+
+        @test typeof(norm(v_int)) <: AbstractFloat
+        @test typeof(norm(v_float)) <: AbstractFloat
+        @test typeof(norm(v_complex)) <: AbstractFloat
+
+        # Different element types
+        @test norm(Int8[3, 4]) ≈ 5.0
+        @test norm(Float32[3, 4]) ≈ 5.0
+        @test norm(BigFloat[3, 4]) ≈ 5.0
+    end
+end


### PR DESCRIPTION
## Summary
This PR adds a complete implementation of norm functions for vectors and matrices in pure Julia, eliminating the need for LinearAlgebra.jl and its associated BLAS/LAPACK dependencies.

## Motivation
SimpleNorm.jl was created to provide norm functions without binary dependencies. This PR delivers on that promise by implementing the core norm functionality from LinearAlgebra.jl in pure Julia.

## Features Added

### Vector Norms
- `norm(x)` or `norm(x, 2)` - Euclidean norm (default)
- `norm(x, 1)` - 1-norm (sum of absolute values)  
- `norm(x, Inf)` - Infinity norm (maximum absolute value)
- `norm(x, -Inf)` - Minimum absolute value
- `norm(x, p)` - p-norm for any `p ≥ 1`
- `norm(x, 0)` - Count of non-zero elements

### Matrix Norms
- `norm(A, 1)` - Maximum absolute column sum
- `norm(A, Inf)` - Maximum absolute row sum
- `norm(A, "fro")` or `norm(A, :fro)` - Frobenius norm

Note: The spectral norm (`norm(A, 2)`) is not implemented as it requires singular value decomposition.

## Implementation Details
- Uses scaling algorithms similar to BLAS dnrm2 to prevent overflow/underflow
- Supports various numeric types including complex numbers
- Type-stable implementations for performance
- Comprehensive test suite with 100% pass rate

## Test Plan
✅ All tests pass locally
✅ Tested with various numeric types (Int8, Float32, Float64, BigFloat, Complex)
✅ Overflow/underflow prevention verified
✅ NaN and Inf handling tested
✅ Empty array edge cases covered

🤖 Generated with [Claude Code](https://claude.ai/code)