### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,20 +14,9 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.42.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What changed

Converts the remaining inline CI to the centralized SciML reusable workflows (`@v1`), each with `secrets: "inherit"`.

**Converted (inline -> central caller):**
- `FormatCheck.yml`: `fredrikekre/runic-action` -> `runic.yml@v1`
- `SpellCheck.yml`: `crate-ci/typos` -> `spellcheck.yml@v1`
- `Downgrade.yml`: inline downgrade matrix -> `downgrade.yml@v1` (preserved `julia-version: 1.10`, `skip: Pkg,TOML`; the previous `ALLOW_RERESOLVE: false` matches the central default `allow-reresolve: false`)

**Already central (left as-is, both have `secrets: "inherit"`):**
- `Tests.yml` -> `tests.yml@v1` (version x os matrix preserved)
- `Documentation.yml` -> `documentation.yml@v1`

**Cleanup:**
- `dependabot.yml`: removed the `crate-ci/typos` ignore entry; narrowed the `julia` ecosystem `directories` to `/` (the only dir with a `Project.toml` — there is no `docs/` or `test/Project.toml`).

Each workflow file keeps its existing `name:`/`on:`/`concurrency:` triggers.

## Checks
- Typos: ran `typos .` -> clean (exit 0), 0 fixes needed.
- Runic: ran `Runic.main(["--inplace","."])` -> no changes (repo was already Runic-clean).

## Notes / issues
- **Documentation:** the repo has a `Documentation.yml` caller but **no `docs/` directory or `docs/make.jl`**. This is pre-existing; the doc build has nothing to build and likely fails. Left untouched (out of scope for this PR) — flagging so it can be removed or a docs setup added.
- No `CompatHelper.yml` present (nothing to delete). `TagBot.yml` left unchanged. No Downstream/Benchmark workflows present.

## Heads up
Job/check names change with the centralized callers (e.g. the Runic, Downgrade, and Spell Check jobs now report under the reusable-workflow job names). **Branch-protection required-status-check names will need updating** to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)