### PR TITLE
Add a simple docs/ for SimpleNorm.jl

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SimpleNorm = "ed573fae-7fee-4d61-b037-fdc8e83b28d4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,22 @@
+using Documenter
+using SimpleNorm
+
+makedocs(
+    sitename = "SimpleNorm.jl",
+    authors = "SciML",
+    modules = [SimpleNorm],
+    clean = true,
+    doctest = false,
+    linkcheck = false,
+    format = Documenter.HTML(;
+        canonical = "https://docs.sciml.ai/SimpleNorm/stable/",
+    ),
+    pages = [
+        "Home" => "index.md",
+    ],
+)
+
+deploydocs(;
+    repo = "github.com/SciML/SimpleNorm.jl.git",
+    push_preview = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,50 @@
+# SimpleNorm.jl
+
+SimpleNorm.jl is a lightweight implementation of norm functions without
+`LinearAlgebra.jl`, BLAS, or LAPACK dependencies. It provides pure-Julia
+`norm` implementations that are useful in dependency-constrained or
+precompilation-sensitive contexts.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("SimpleNorm")
+```
+
+## Usage
+
+```julia
+using SimpleNorm
+
+norm([3.0, 4.0])        # 5.0  (Euclidean / 2-norm, the default)
+norm([3.0, 4.0], 1)     # 7.0  (1-norm)
+norm([3.0, 4.0], Inf)   # 4.0  (infinity norm)
+```
+
+## Supported norms
+
+### Vector norms
+
+- `norm(x)` or `norm(x, 2)` — Euclidean norm (default)
+- `norm(x, 1)` — 1-norm (sum of absolute values)
+- `norm(x, Inf)` — infinity norm (maximum absolute value)
+- `norm(x, -Inf)` — minimum absolute value
+- `norm(x, p)` — p-norm for any `p ≥ 1`
+- `norm(x, 0)` — count of non-zero elements
+
+### Matrix norms
+
+- `norm(A, 1)` — maximum absolute column sum
+- `norm(A, Inf)` — maximum absolute row sum
+- `norm(A, "fro")` or `norm(A, :fro)` — Frobenius norm
+
+!!! note
+    The spectral norm (`norm(A, 2)`) is not implemented, as it requires a
+    singular value decomposition.
+
+## API
+
+```@docs
+SimpleNorm.norm
+```


### PR DESCRIPTION
> Ignore until reviewed by @ChrisRackauckas. Draft.

The centralized `documentation.yml@v1` workflow is enabled on main, but there was no `docs/` to build. Adds a minimal Documenter setup (Project.toml, make.jl, index.md) — installation, usage, the supported vector/matrix norms, and the `norm` docstring via `@docs`. **Verified locally**: `julia --project=docs docs/make.jl` builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)