### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -22,20 +22,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        os:
-          - "ubuntu-latest"
-          - "macos-latest"
-          - "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,8 @@ version = "0.1.0"
 
 [compat]
 ExplicitImports = "1"
-julia = "1.6"
+Test = "1"
+julia = "1.10"
 
 [extras]
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,17 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 version = "0.1.0"
 
 [compat]
+Aqua = "0.8"
 ExplicitImports = "1"
+JET = "0.9,0.10,0.11"
 Test = "1"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "Test"]
+test = ["Aqua", "ExplicitImports", "JET", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SimpleNorm = "ed573fae-7fee-4d61-b037-fdc8e83b28d4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+SimpleNorm = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9,0.10,0.11"
+Test = "1"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using SimpleNorm
+using Aqua
+using JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(SimpleNorm)
+end
+
+@testset "JET" begin
+    JET.test_package(SimpleNorm; target_defined_modules = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,15 @@
 using SimpleNorm
 using Test
 
+const GROUP = get(ENV, "GROUP", "All")
+
+if GROUP == "QA"
+    @testset "QA" begin
+        include("qa/qa.jl")
+    end
+end
+
+if GROUP == "All" || GROUP == "Core"
 @testset "Explicit Imports" begin
     include("explicit_imports_test.jl")
 end
@@ -146,4 +155,5 @@ end
         @test norm(Float32[3, 4]) ≈ 5.0
         @test norm(BigFloat[3, 4]) ≈ 5.0
     end
+end
 end

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,6 @@
+[Core]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "windows-latest", "macos-latest"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root `Tests.yml` workflow to the canonical **thin caller** for `SciML/.github/.github/workflows/grouped-tests.yml@v1`, moving the group × version (× os) matrix into a root `test/test_groups.toml`.

### Changes
- **`.github/workflows/Tests.yml`** — replace the hand-maintained `version × os` matrix job with the reusable `grouped-tests.yml@v1` caller (`secrets: inherit`, no `with:` needed — all inputs are defaults: GROUP env, check-bounds `yes`, coverage on, `src,ext`). `on:` and `concurrency:` preserved verbatim. Filename and `name:` unchanged. Other workflows untouched.
- **`test/test_groups.toml`** (new) — `Core` on `[lts, 1, pre]` × `[ubuntu-latest, windows-latest, macos-latest]`; `QA` on `[lts, 1]`.
- **`test/runtests.jl`** — add `GROUP` dispatch. Existing suite (ExplicitImports + norm tests) runs under `Core`/`All`; new `QA` branch includes `test/qa/qa.jl`.
- **`test/qa/`** (new) — `Aqua.test_all(SimpleNorm)` + `JET.test_package(SimpleNorm; target_defined_modules=true)`, with its own `Project.toml` ([sources] path to root; compat Aqua 0.8, JET 0.9,0.10,0.11, Test 1, julia 1.10).
- **`Project.toml`** — bump `julia` compat `1.6` → `1.10` (LTS floor; also clears Aqua's project_extras check); add missing `Test = "1"` compat for the `[extras]` dep. Benign metadata fixes, not silencing.

### Matrix match
Old `Tests.yml` matrix: `{1, lts, pre} × {ubuntu-latest, macos-latest, windows-latest}` = 9 full-suite cells.
New `Core` group reproduces this **exactly** (9 cells, same versions × same 3 OSes), verified statically with `compute_affected_sublibraries.jl --root-matrix`. `QA` adds 2 net-new cells (`{lts, 1}` on ubuntu).

### Notes
- QA group is newly wired; Aqua/JET run in CI for the first time here — any failures will be triaged in a follow-up. No exclusions were pre-added.
- This is a structural conversion; tests/Aqua/JET were **not** run locally. TOML/YAML/Julia files were statically parse-verified only.

**Ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)