### PR TITLE
Canonicalize test units to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 Aqua = "0.8"
 ExplicitImports = "1"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"
 
@@ -14,7 +15,8 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "JET", "Test"]
+test = ["Aqua", "ExplicitImports", "JET", "SafeTestsets", "Test"]

--- a/test/norm_tests.jl
+++ b/test/norm_tests.jl
@@ -1,0 +1,143 @@
+using SimpleNorm
+using Test
+
+@testset "Vector norms" begin
+    # Test vectors
+    v1 = [3.0, 4.0]
+    v2 = [1.0, -2.0, 3.0, -4.0]
+    v3 = Float64[]
+    v4 = [1.0 + 2.0im, 3.0 - 4.0im]
+
+    # 2-norm (default)
+    @test norm(v1) ≈ 5.0
+    @test norm(v1, 2) ≈ 5.0
+    @test norm(v2, 2) ≈ sqrt(1 + 4 + 9 + 16)
+    @test norm(v3) == 0.0
+
+    # 1-norm
+    @test norm(v1, 1) ≈ 7.0
+    @test norm(v2, 1) ≈ 10.0
+    @test norm(v3, 1) == 0.0
+
+    # Infinity norm
+    @test norm(v1, Inf) ≈ 4.0
+    @test norm(v2, Inf) ≈ 4.0
+    @test norm(v3, Inf) == 0.0
+
+    # Negative infinity norm
+    @test norm(v1, -Inf) ≈ 3.0
+    @test norm(v2, -Inf) ≈ 1.0
+
+    # 0-norm (counting non-zeros)
+    @test norm(v1, 0) == 2.0
+    @test norm(v2, 0) == 4.0
+    @test norm([1.0, 0.0, 3.0, 0.0, 5.0], 0) == 3.0
+
+    # p-norm for various p
+    @test norm(v1, 3) ≈ (3^3 + 4^3)^(1 / 3)
+    @test norm(v2, 4) ≈ (1 + 16 + 81 + 256)^(1 / 4)
+
+    # Complex vectors
+    @test norm(v4, 1) ≈ sqrt(5) + 5
+    @test norm(v4, 2) ≈ sqrt(5 + 25)
+    @test norm(v4, Inf) ≈ 5.0
+end
+
+@testset "Matrix norms" begin
+    A = [
+        1.0 2.0 3.0;
+        4.0 5.0 6.0
+    ]
+
+    B = [
+        1.0 -2.0;
+        3.0 4.0;
+        -5.0 6.0
+    ]
+
+    # 1-norm (maximum column sum)
+    @test norm(A, 1) ≈ 9.0  # max(1+4, 2+5, 3+6)
+    @test norm(B, 1) ≈ 12.0  # max(1+3+5, 2+4+6)
+
+    # Infinity norm (maximum row sum)
+    @test norm(A, Inf) ≈ 15.0  # max(1+2+3, 4+5+6)
+    @test norm(B, Inf) ≈ 11.0  # max(1+2, 3+4, 5+6)
+
+    # Frobenius norm
+    @test norm(A, "fro") ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
+    @test norm(A, :fro) ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
+    @test norm(B, "fro") ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
+
+    # Empty matrix
+    @test norm(zeros(0, 0), 1) == 0.0
+    @test norm(zeros(0, 5), 1) == 0.0
+    @test norm(zeros(5, 0), Inf) == 0.0
+end
+
+@testset "Scalar norms" begin
+    @test norm(5.0) == 5.0
+    @test norm(-3.0) == 3.0
+    @test norm(3.0 + 4.0im) == 5.0
+    @test norm(0.0) == 0.0
+
+    # All p-norms of a scalar should return absolute value
+    @test norm(5.0, 1) == 5.0
+    @test norm(-3.0, 2) == 3.0
+    @test norm(5.0, Inf) == 5.0
+end
+
+@testset "Special cases" begin
+    # Infinity and NaN handling
+    v_inf = [1.0, Inf, 3.0]
+    v_nan = [1.0, NaN, 3.0]
+
+    @test norm(v_inf, 1) == Inf
+    @test norm(v_inf, 2) == Inf
+    @test norm(v_inf, Inf) == Inf
+    @test isnan(norm(v_nan, 1))
+    @test isnan(norm(v_nan, 2))
+    @test isnan(norm(v_nan, Inf))
+
+    # Large values (overflow prevention)
+    large_val = 1.0e308
+    v_large = [large_val, large_val]
+    @test norm(v_large, 2) ≈ sqrt(2) * large_val
+    @test !isinf(norm(v_large, 2))
+
+    # Small values (underflow prevention)
+    small_val = 1.0e-308
+    v_small = [small_val, small_val]
+    @test norm(v_small, 2) ≈ sqrt(2) * small_val
+    @test norm(v_small, 2) > 0
+end
+
+@testset "Error handling" begin
+    v = [1.0, 2.0, 3.0]
+
+    # Invalid p values
+    @test_throws ArgumentError norm(v, -2)
+    @test_throws ArgumentError norm(v, -0.5)
+
+    # Matrix 2-norm not implemented
+    A = [1.0 2.0; 3.0 4.0]
+    @test_throws ErrorException norm(A, 2)
+
+    # Invalid matrix norm
+    @test_throws ArgumentError norm(A, 3)
+end
+
+@testset "Type stability" begin
+    # Test that output types are predictable
+    v_int = [1, 2, 3]
+    v_float = [1.0, 2.0, 3.0]
+    v_complex = [1.0 + 0.0im, 2.0 + 0.0im]
+
+    @test typeof(norm(v_int)) <: AbstractFloat
+    @test typeof(norm(v_float)) <: AbstractFloat
+    @test typeof(norm(v_complex)) <: AbstractFloat
+
+    # Different element types
+    @test norm(Int8[3, 4]) ≈ 5.0
+    @test norm(Float32[3, 4]) ≈ 5.0
+    @test norm(BigFloat[3, 4]) ≈ 5.0
+end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SimpleNorm = "ed573fae-7fee-4d61-b037-fdc8e83b28d4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -10,5 +11,6 @@ SimpleNorm = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,12 +1,15 @@
-using SimpleNorm
-using Aqua
-using JET
-using Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using SimpleNorm
+    using Aqua
+    using Test
     Aqua.test_all(SimpleNorm)
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using SimpleNorm
+    using JET
+    using Test
     JET.test_package(SimpleNorm; target_defined_modules = true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using SimpleNorm
 using Test
+using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -10,150 +11,11 @@ if GROUP == "QA"
 end
 
 if GROUP == "All" || GROUP == "Core"
-    @testset "Explicit Imports" begin
+    @safetestset "Explicit Imports" begin
         include("explicit_imports_test.jl")
     end
 
-    @testset "SimpleNorm.jl" begin
-        @testset "Vector norms" begin
-            # Test vectors
-            v1 = [3.0, 4.0]
-            v2 = [1.0, -2.0, 3.0, -4.0]
-            v3 = Float64[]
-            v4 = [1.0 + 2.0im, 3.0 - 4.0im]
-
-            # 2-norm (default)
-            @test norm(v1) ≈ 5.0
-            @test norm(v1, 2) ≈ 5.0
-            @test norm(v2, 2) ≈ sqrt(1 + 4 + 9 + 16)
-            @test norm(v3) == 0.0
-
-            # 1-norm
-            @test norm(v1, 1) ≈ 7.0
-            @test norm(v2, 1) ≈ 10.0
-            @test norm(v3, 1) == 0.0
-
-            # Infinity norm
-            @test norm(v1, Inf) ≈ 4.0
-            @test norm(v2, Inf) ≈ 4.0
-            @test norm(v3, Inf) == 0.0
-
-            # Negative infinity norm
-            @test norm(v1, -Inf) ≈ 3.0
-            @test norm(v2, -Inf) ≈ 1.0
-
-            # 0-norm (counting non-zeros)
-            @test norm(v1, 0) == 2.0
-            @test norm(v2, 0) == 4.0
-            @test norm([1.0, 0.0, 3.0, 0.0, 5.0], 0) == 3.0
-
-            # p-norm for various p
-            @test norm(v1, 3) ≈ (3^3 + 4^3)^(1 / 3)
-            @test norm(v2, 4) ≈ (1 + 16 + 81 + 256)^(1 / 4)
-
-            # Complex vectors
-            @test norm(v4, 1) ≈ sqrt(5) + 5
-            @test norm(v4, 2) ≈ sqrt(5 + 25)
-            @test norm(v4, Inf) ≈ 5.0
-        end
-
-        @testset "Matrix norms" begin
-            A = [
-                1.0 2.0 3.0;
-                4.0 5.0 6.0
-            ]
-
-            B = [
-                1.0 -2.0;
-                3.0 4.0;
-                -5.0 6.0
-            ]
-
-            # 1-norm (maximum column sum)
-            @test norm(A, 1) ≈ 9.0  # max(1+4, 2+5, 3+6)
-            @test norm(B, 1) ≈ 12.0  # max(1+3+5, 2+4+6)
-
-            # Infinity norm (maximum row sum)
-            @test norm(A, Inf) ≈ 15.0  # max(1+2+3, 4+5+6)
-            @test norm(B, Inf) ≈ 11.0  # max(1+2, 3+4, 5+6)
-
-            # Frobenius norm
-            @test norm(A, "fro") ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
-            @test norm(A, :fro) ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
-            @test norm(B, "fro") ≈ sqrt(1 + 4 + 9 + 16 + 25 + 36)
-
-            # Empty matrix
-            @test norm(zeros(0, 0), 1) == 0.0
-            @test norm(zeros(0, 5), 1) == 0.0
-            @test norm(zeros(5, 0), Inf) == 0.0
-        end
-
-        @testset "Scalar norms" begin
-            @test norm(5.0) == 5.0
-            @test norm(-3.0) == 3.0
-            @test norm(3.0 + 4.0im) == 5.0
-            @test norm(0.0) == 0.0
-
-            # All p-norms of a scalar should return absolute value
-            @test norm(5.0, 1) == 5.0
-            @test norm(-3.0, 2) == 3.0
-            @test norm(5.0, Inf) == 5.0
-        end
-
-        @testset "Special cases" begin
-            # Infinity and NaN handling
-            v_inf = [1.0, Inf, 3.0]
-            v_nan = [1.0, NaN, 3.0]
-
-            @test norm(v_inf, 1) == Inf
-            @test norm(v_inf, 2) == Inf
-            @test norm(v_inf, Inf) == Inf
-            @test isnan(norm(v_nan, 1))
-            @test isnan(norm(v_nan, 2))
-            @test isnan(norm(v_nan, Inf))
-
-            # Large values (overflow prevention)
-            large_val = 1.0e308
-            v_large = [large_val, large_val]
-            @test norm(v_large, 2) ≈ sqrt(2) * large_val
-            @test !isinf(norm(v_large, 2))
-
-            # Small values (underflow prevention)
-            small_val = 1.0e-308
-            v_small = [small_val, small_val]
-            @test norm(v_small, 2) ≈ sqrt(2) * small_val
-            @test norm(v_small, 2) > 0
-        end
-
-        @testset "Error handling" begin
-            v = [1.0, 2.0, 3.0]
-
-            # Invalid p values
-            @test_throws ArgumentError norm(v, -2)
-            @test_throws ArgumentError norm(v, -0.5)
-
-            # Matrix 2-norm not implemented
-            A = [1.0 2.0; 3.0 4.0]
-            @test_throws ErrorException norm(A, 2)
-
-            # Invalid matrix norm
-            @test_throws ArgumentError norm(A, 3)
-        end
-
-        @testset "Type stability" begin
-            # Test that output types are predictable
-            v_int = [1, 2, 3]
-            v_float = [1.0, 2.0, 3.0]
-            v_complex = [1.0 + 0.0im, 2.0 + 0.0im]
-
-            @test typeof(norm(v_int)) <: AbstractFloat
-            @test typeof(norm(v_float)) <: AbstractFloat
-            @test typeof(norm(v_complex)) <: AbstractFloat
-
-            # Different element types
-            @test norm(Int8[3, 4]) ≈ 5.0
-            @test norm(Float32[3, 4]) ≈ 5.0
-            @test norm(BigFloat[3, 4]) ≈ 5.0
-        end
+    @safetestset "SimpleNorm.jl" begin
+        include("norm_tests.jl")
     end
 end


### PR DESCRIPTION
## Summary

Wraps each independent top-level test unit in `@safetestset` so it runs in its own module (test isolation + world-age safety), matching the canonical OrdinaryDiffEq test structure.

## Changes

- **`test/runtests.jl`**: the `"Explicit Imports"` and `"SimpleNorm.jl"` units become `@safetestset ... begin include(...) end`. The previously-inline `"SimpleNorm.jl"` body was extracted to a new self-contained `test/norm_tests.jl` (with its own `using SimpleNorm; using Test`). Nested grouping `@testset`s inside a unit stay plain `@testset` (the unit-level `@safetestset` already isolates).
- **`test/qa/qa.jl`**: the `"Aqua"` and `"JET"` units become `@safetestset`, each carrying its own `using` lines.
- **Deps**: added `SafeTestsets` (`1bc83da4-3b8d-516f-aca4-4fe02f6d838f`) to the root `[extras]`/`[targets].test` + `[compat] SafeTestsets = "0.1, 1"`, and to `test/qa/Project.toml` (the QA group activates its own env).

## Behavior-preserving

Same tests run under the same `GROUP` dispatch ladder, same assertions. The GROUP-dispatch / `runtests` harness structure is untouched beyond wrapping units.

## Verification

Verified locally on julia 1.11:
- `GROUP=Core` -> Explicit Imports 2/2, SimpleNorm.jl 57/57 pass.
- `GROUP=QA` -> 12/12 pass.

---

Draft. Ignore until reviewed by @ChrisRackauckas.