### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNorm"
 uuid = "ed573fae-7fee-4d61-b037-fdc8e83b28d4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [compat]
 SafeTestsets = "0.1, 1"


### PR DESCRIPTION
Automated patch version bump (0.1.1 -> 0.1.2) to release unreleased commits on `main` via JuliaRegistrator.