### PR TITLE
Allow SciMLTesting v2 in QA compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.1.2"
 
 [compat]
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.5"
+SciMLTesting = "1.5, 2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SimpleNorm = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.5"
+SciMLTesting = "1.5, 2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Allows `SciMLTesting` v2 in the root test compat and QA environment compat.
- Leaves the test/QA setup unchanged.

## Verification

- `git diff --check`
- Runic check on `Project.toml` and `test/qa/Project.toml`.
- TOML parse/assert confirmed both files have `SciMLTesting = "1.5, 2.1"`.
- `julia --project=. -e 'using Pkg; Pkg.Registry.add("General"); Pkg.test(; coverage=false)'` passed, `57` tests, with `SciMLTesting v2.2.0` selected.
- `julia --project=test/qa -e 'using Pkg; Pkg.Registry.add("General"); Pkg.resolve(); Pkg.status(["SciMLTesting"]); include("test/qa/qa.jl")'` passed, `19` QA tests, with `SciMLTesting v2.2.0` selected.
