### PR TITLE
Remove SciMLTesting v1 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.1.2"
 
 [compat]
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.5, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SimpleNorm = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.5, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Set SciMLTesting compat to exactly `2.1` in the root and QA project files.
- No source, docs, workflows, or test code changed.

## Validation
- `git diff --check`
- Runic v1.7.0 over tracked `*.jl` files with Julia 1.10.11 and a repo-local depot
- `GROUP=Core` `Pkg.test()` with Julia 1.10.11 and a repo-local depot
- `GROUP=QA` `Pkg.test()` with Julia 1.10.11 and a repo-local depot

Generated local depots, temp envs, and manifests were removed after validation.