### PR TITLE
Document SimpleNorm public API

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ norm([3.0, 4.0], Inf)   # 4.0  (infinity norm)
 - `norm(x, 1)` — 1-norm (sum of absolute values)
 - `norm(x, Inf)` — infinity norm (maximum absolute value)
 - `norm(x, -Inf)` — minimum absolute value
-- `norm(x, p)` — p-norm for any `p ≥ 1`
+- `norm(x, p)` — scaled positive-order norm for any `p > 0`
 - `norm(x, 0)` — count of non-zero elements
 
 ### Matrix norms

--- a/src/SimpleNorm.jl
+++ b/src/SimpleNorm.jl
@@ -4,25 +4,47 @@ export norm
 
 """
     norm(x, p::Real=2)
+    norm(A::AbstractMatrix, p::Union{AbstractString, Symbol})
 
-Compute the p-norm of a vector or array.
+Compute a scalar norm using pure Julia implementations that do not depend on
+`LinearAlgebra`, BLAS, or LAPACK.
 
-For vectors and arrays, the p-norm is defined as:
-- `p = 1`: sum of absolute values
-- `p = 2`: Euclidean norm (default)
-- `p = Inf`: maximum absolute value
-- `p = -Inf`: minimum absolute value
-- `p = 0`: count of non-zero elements
-- `p > 0`: (Σ|xᵢ|^p)^(1/p)
+# Arguments
 
-For matrices, special norms are supported:
-- `p = 1`: maximum absolute column sum
-- `p = Inf`: maximum absolute row sum
-- `p = "fro"` or `p = :fro`: Frobenius norm
-- `p = 2`: spectral norm (not implemented, as it requires SVD)
+  - `x`: A number or array-like collection of numeric values.
+  - `A`: An `AbstractMatrix` for matrix-specific norms.
+  - `p`: The requested norm order. Defaults to `2`.
 
-This implementation does not depend on BLAS or LAPACK and uses scaling
-algorithms to prevent overflow and underflow in floating-point computations.
+# Supported Values
+
+For vectors and general arrays:
+
+  - `p = 1`: sum of absolute values.
+  - `p = 2`: Euclidean norm.
+  - `p = Inf`: maximum absolute value.
+  - `p = -Inf`: minimum absolute value.
+  - `p = 0`: count of non-zero elements.
+  - `p > 0`: scaled ``(sum(abs(x_i)^p))^(1/p)`` computation.
+
+For matrices:
+
+  - `p = 1`: maximum absolute column sum.
+  - `p = Inf`: maximum absolute row sum.
+  - `p = "fro"` or `p = :fro`: Frobenius norm.
+
+For numbers, all supported `p` values return `abs(x)`.
+
+# Errors
+
+Throws `ArgumentError` for unsupported negative vector orders, unsupported matrix
+orders, and unknown matrix norm strings or symbols. Matrix spectral norms
+(`p = 2`) are intentionally not implemented because they require singular value
+decomposition.
+
+# Notes
+
+The Euclidean, general positive-order, and Frobenius paths use scaling algorithms
+to reduce overflow and underflow in floating-point computations.
 
 # Examples
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,4 @@
 using SciMLTesting, SimpleNorm, Test
 using JET
 
-run_qa(SimpleNorm; explicit_imports = true)
+run_qa(SimpleNorm; explicit_imports = true, api_docs_kwargs = (; rendered = true))


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- Expands the exported `norm` docstring with SciMLStyle-style signatures, arguments, supported values, errors, notes, and examples.
- Aligns the docs prose with the implementation for positive-order norms (`p > 0`).
- Enables SciMLTesting's shared rendered public API docs check with `api_docs_kwargs = (; rendered = true)`.

## Validation

- `git diff --check`
- Runic check over `src`, `test`, and `docs` with Runic v1.7.0.
- `timeout 3600 env JULIA_DEPOT_PATH="$PWD/.qa_depot" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate(); include("test/qa/qa.jl")'`
- `timeout 3600 env JULIA_DEPOT_PATH="$PWD/.docs_depot" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate(); include("docs/make.jl")'`
- `timeout 3600 env JULIA_DEPOT_PATH="$PWD/.test_depot" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
