### PR TITLE
Remove SimpleNorm QA docs override

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,4 @@
 using SciMLTesting, SimpleNorm, Test
 using JET
 
-run_qa(SimpleNorm; explicit_imports = true, api_docs_kwargs = (; rendered = true))
+run_qa(SimpleNorm; explicit_imports = true)


### PR DESCRIPTION
Removes the repository-specific `api_docs_kwargs = (; rendered = true)` override from the QA invocation.

SciMLTesting already has a `2.1` compat, so the shared QA default now applies without changing package code or documentation.

Validation:
- `Runic.main(["--check", "--docstrings", "."])` with Runic 1.7.0
- `GROUP=QA Pkg.test()` on Julia 1.10
- `Pkg.test()` on Julia 1.10 (57/57)

Ignore until reviewed by @ChrisRackauckas.