### PR TITLE
Bump SimpleNorm to v0.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNorm"
 uuid = "ed573fae-7fee-4d61-b037-fdc8e83b28d4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [compat]
 SafeTestsets = "0.1, 1"


### PR DESCRIPTION
Bumps `SimpleNorm` **v0.1.2 → v0.1.3** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Remove SimpleNorm QA docs override (#27) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)