### PR TITLE
Require strict SciMLTesting 2.4 QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.1.3"
 
 [compat]
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,8 +6,6 @@ makedocs(
     authors = "SciML",
     modules = [SimpleNorm],
     clean = true,
-    doctest = false,
-    linkcheck = false,
     format = Documenter.HTML(;
         canonical = "https://docs.sciml.ai/SimpleNorm/stable/",
     ),

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,13 +14,27 @@ Pkg.add("SimpleNorm")
 
 ## Usage
 
-```julia
-using SimpleNorm
+```jldoctest
+julia> using SimpleNorm
 
-norm([3.0, 4.0])        # 5.0  (Euclidean / 2-norm, the default)
-norm([3.0, 4.0], 1)     # 7.0  (1-norm)
-norm([3.0, 4.0], Inf)   # 4.0  (infinity norm)
+julia> norm([3.0, 4.0])
+5.0
+
+julia> norm([3.0, 4.0], 1)
+7.0
+
+julia> norm([3.0, 4.0], Inf)
+4.0
 ```
+
+## Array contract
+
+`norm` accepts ordinary arrays and custom `AbstractArray` implementations. A
+custom array must implement the public Base array operations used by its shape:
+iteration, `isempty`, `eltype`, and scalar indexing; matrices must additionally
+implement `size` and two-dimensional scalar indexing. There is no
+SimpleNorm-specific abstract type to subtype or method to extend. Define the
+normal Base array interface, then call `norm`.
 
 ## Supported norms
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@ julia> norm([3.0, 4.0], Inf)
 `norm` accepts ordinary arrays and custom `AbstractArray` implementations. A
 custom array must implement the public Base array operations used by its shape:
 iteration, `isempty`, `eltype`, and scalar indexing; matrices must additionally
-implement `size` and two-dimensional scalar indexing. There is no
+implement axes and two-dimensional scalar indexing over those axes. There is no
 SimpleNorm-specific abstract type to subtype or method to extend. Define the
 normal Base array interface, then call `norm`.
 

--- a/src/SimpleNorm.jl
+++ b/src/SimpleNorm.jl
@@ -3,21 +3,28 @@ module SimpleNorm
 export norm
 
 """
-    norm(x, p::Real=2)
-    norm(A::AbstractMatrix, p::Union{AbstractString, Symbol})
+    norm(x[, p]) -> Real
+    norm(A::AbstractMatrix, p::Union{AbstractString, Symbol}) -> Real
 
-Compute a scalar norm using pure Julia implementations that do not depend on
-`LinearAlgebra`, BLAS, or LAPACK.
+Compute a scalar norm using pure-Julia implementations that do not depend on
+`LinearAlgebra`, BLAS, or LAPACK. `norm(x)` is equivalent to `norm(x, 2)`.
 
 # Arguments
 
-  - `x`: A number or array-like collection of numeric values.
-  - `A`: An `AbstractMatrix` for matrix-specific norms.
-  - `p`: The requested norm order. Defaults to `2`.
+  - `x::Union{Number, AbstractArray}`: A number or array of numeric values.
+  - `A::AbstractMatrix`: A matrix for matrix-specific norms.
+  - `p::Real`: The requested numeric norm order. It defaults to `2` when omitted.
+    Matrices also accept `"fro"` or `:fro` for the Frobenius norm.
+
+# Returns
+
+The absolute value for numbers, or a real floating-point scalar for array
+inputs. Empty arrays return the floating-point zero corresponding to their
+element type.
 
 # Supported Values
 
-For vectors and general arrays:
+For vectors and general arrays, including custom `AbstractArray` implementations:
 
   - `p = 1`: sum of absolute values.
   - `p = 2`: Euclidean norm.
@@ -34,7 +41,16 @@ For matrices:
 
 For numbers, all supported `p` values return `abs(x)`.
 
-# Errors
+# Array Interface
+
+`norm` consumes the public `AbstractArray` interface; custom arrays must support
+their usual public Base operations, including iteration, `isempty`, `eltype`,
+and scalar indexing. Matrix inputs must additionally support `size(A)` and
+two-dimensional scalar indexing `A[i, j]`. No SimpleNorm-specific subtype or
+method extension is required: define the normal `AbstractArray` interface and
+call `norm` on the resulting value.
+
+# Throws
 
 Throws `ArgumentError` for unsupported negative vector orders, unsupported matrix
 orders, and unknown matrix norm strings or symbols. Matrix spectral norms
@@ -48,18 +64,19 @@ to reduce overflow and underflow in floating-point computations.
 
 # Examples
 
-```julia
-# Vector norms
-v = [3.0, 4.0]
-norm(v)       # 5.0
-norm(v, 1)    # 7.0
-norm(v, Inf)  # 4.0
+```jldoctest
+julia> using SimpleNorm
 
-# Matrix norms
-A = [1 2 3; 4 5 6]
-norm(A, 1)     # 9.0
-norm(A, Inf)   # 15.0
-norm(A, :fro)  # 9.539392014169456
+julia> SimpleNorm.norm([3.0, 4.0])
+5.0
+
+julia> SimpleNorm.norm([3.0, 4.0], 1)
+7.0
+
+julia> A = [1 2 3; 4 5 6];
+
+julia> SimpleNorm.norm(A, :fro)
+9.539392014169456
 ```
 """
 norm(x) = norm(x, 2)

--- a/src/SimpleNorm.jl
+++ b/src/SimpleNorm.jl
@@ -45,10 +45,10 @@ For numbers, all supported `p` values return `abs(x)`.
 
 `norm` consumes the public `AbstractArray` interface; custom arrays must support
 their usual public Base operations, including iteration, `isempty`, `eltype`,
-and scalar indexing. Matrix inputs must additionally support `size(A)` and
-two-dimensional scalar indexing `A[i, j]`. No SimpleNorm-specific subtype or
-method extension is required: define the normal `AbstractArray` interface and
-call `norm` on the resulting value.
+and scalar indexing. Matrix inputs must additionally provide axes and
+two-dimensional scalar indexing `A[i, j]` for values from those axes. No
+SimpleNorm-specific subtype or method extension is required: define the normal
+`AbstractArray` interface and call `norm` on the resulting value.
 
 # Throws
 
@@ -238,16 +238,15 @@ end
 # Matrix norm implementations
 
 function norm1_matrix(A::AbstractMatrix)
-    m, n = size(A)
-    if m == 0 || n == 0
+    if isempty(A)
         return float(abs(zero(eltype(A))))
     end
 
     # Maximum absolute column sum
     maxsum = zero(float(real(eltype(A))))
-    for j in 1:n
+    for j in axes(A, 2)
         colsum = zero(float(real(eltype(A))))
-        for i in 1:m
+        for i in axes(A, 1)
             colsum += abs(A[i, j])
         end
         maxsum = max(maxsum, colsum)
@@ -256,16 +255,15 @@ function norm1_matrix(A::AbstractMatrix)
 end
 
 function normInf_matrix(A::AbstractMatrix)
-    m, n = size(A)
-    if m == 0 || n == 0
+    if isempty(A)
         return float(abs(zero(eltype(A))))
     end
 
     # Maximum absolute row sum
     maxsum = zero(float(real(eltype(A))))
-    for i in 1:m
+    for i in axes(A, 1)
         rowsum = zero(float(real(eltype(A))))
-        for j in 1:n
+        for j in axes(A, 2)
             rowsum += abs(A[i, j])
         end
         maxsum = max(maxsum, rowsum)

--- a/test/norm_tests.jl
+++ b/test/norm_tests.jl
@@ -141,3 +141,29 @@ end
     @test norm(Float32[3, 4]) ≈ 5.0
     @test norm(BigFloat[3, 4]) ≈ 5.0
 end
+
+@testset "Generic AbstractArray contract" begin
+    struct WrappedVector{T, V <: AbstractVector{T}} <: AbstractVector{T}
+        data::V
+    end
+
+    Base.IndexStyle(::Type{<:WrappedVector}) = IndexLinear()
+    Base.size(x::WrappedVector) = size(x.data)
+    Base.getindex(x::WrappedVector, i::Int) = x.data[i]
+
+    struct WrappedMatrix{T, M <: AbstractMatrix{T}} <: AbstractMatrix{T}
+        data::M
+    end
+
+    Base.size(x::WrappedMatrix) = size(x.data)
+    Base.getindex(x::WrappedMatrix, i::Int, j::Int) = x.data[i, j]
+
+    v = WrappedVector([3.0, 4.0])
+    A = WrappedMatrix([1.0 2.0; 3.0 4.0])
+
+    @test norm(v) == 5.0
+    @test norm(v, 1) == 7.0
+    @test norm(A, 1) == 6.0
+    @test norm(A, Inf) == 7.0
+    @test norm(A, :fro) == sqrt(30.0)
+end

--- a/test/norm_tests.jl
+++ b/test/norm_tests.jl
@@ -156,7 +156,9 @@ end
     end
 
     Base.size(x::WrappedMatrix) = size(x.data)
-    Base.getindex(x::WrappedMatrix, i::Int, j::Int) = x.data[i, j]
+    Base.axes(::WrappedMatrix) = (0:1, -1:0)
+    Base.getindex(x::WrappedMatrix, i::Int) = x.data[i]
+    Base.getindex(x::WrappedMatrix, i::Int, j::Int) = x.data[i + 1, j + 2]
 
     v = WrappedVector([3.0, 4.0])
     A = WrappedMatrix([1.0 2.0; 3.0 4.0])

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,18 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SimpleNorm = "ed573fae-7fee-4d61-b037-fdc8e83b28d4"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[sources]
-SimpleNorm = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
-Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,3 @@
-using SciMLTesting, SimpleNorm, Test
-using JET
+using SciMLTesting, SimpleNorm
 
-run_qa(SimpleNorm; explicit_imports = true)
+run_qa(SimpleNorm)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- require SciMLTesting 2.4 and run plain `run_qa(SimpleNorm)` without repository-specific configuration or source paths
- enable documentation doctests and refresh the public `norm` API reference with SciMLStyle arguments, returns, throws, and `AbstractArray` contract guidance
- make matrix 1- and infinity-norm loops respect public `axes`, and add generic vector plus non-one-based matrix contract coverage

## Local validation
- `Pkg.test()` on Julia 1.10.11 and 1.12.6: 62/62 assertions
- strict `run_qa(SimpleNorm)` on Julia 1.10.11: 18/18; Julia 1.12.6: 20/20
- documentation build with doctests on Julia 1.10.11
- Runic and `git diff --check`

The initial clean-checkout package tests and intended QA environment were already green. The only preliminary root-QA failure came from activating the root environment, which lacks Aqua; strict QA correctly runs in its dedicated QA environment.